### PR TITLE
added min & max article processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
+                            <tr id="aggDisplay">
                                 <td id = "vice"></td>
                                 <td id = "huff"></td>
                                 <td id = "bbc"></td>
@@ -101,6 +101,12 @@
                     </table>
 
                 </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12">
+                <br>
+                <div id="recent-searches"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
There are a number of updates:

1. created a new variable to change articles returned for each source to make it easier to switch. Because of rate limiting, for development, 2 per should be sufficient.

2. It's not ideal, but I solved the asynchronous issue where article results were not persisting after the search button click event by adding a timeout, so when you click `Search` there will be a 5 second lag.

3. I added the method for getting the min and max articles for the article result divs. It was more difficult than I originally thought, but I think the solution works well (returns an array of top article objects, ordered by sentiment score [and the reverse for min])

4. I added the recent search buttons to the bottom of the page from Firebase and added a click event to each (currently all it does is log the id for the corresponding topic).